### PR TITLE
fix: 今日のゴールを自己紹介の下方向遷移に変更

### DIFF
--- a/src/slides/nix-darwin-home-manager.md
+++ b/src/slides/nix-darwin-home-manager.md
@@ -21,8 +21,7 @@ author: himihiromu
     - [eza](https://github.com/eza-community/eza)
     - [bat](https://github.com/sharkdp/bat)
 
-# 今日のゴール
-
+## 今日のゴール
 - Nix を使った Mac 構成管理の実例を共有する
 - 便利さとつらさの両方を伝える
 


### PR DESCRIPTION
## 修正内容

- 「今日のゴール」をH1からH2に変更し、自己紹介スライドの下に配置
- Reveal.jsのverticalスライド機能で下方向に遷移するように変更